### PR TITLE
Add DDS tone setting helper function

### DIFF
--- a/DDS.m
+++ b/DDS.m
@@ -143,6 +143,74 @@ classdef (Abstract) DDS < matlabshared.libiio.base
                 obj.DDSUpdate();
             end
         end
+
+        % Helpers
+        function DDSSingleTone(obj, frequency, scale, channel)
+            % Set DDS to generate a tone from single channel. All other
+            % channels will be disabled. Inputs:
+            %   frequency: Frequency in Hz of tone
+            %   scale: Scale of tone from 0->1
+            %   channel: Channel to generate tone on (1->max(EnabledChannels)
+
+            if isempty(obj.dds_channel_names)
+                 chans = length(obj.channel_names);
+            else               
+                 chans = length(obj.dds_channel_names);
+            end
+            
+            if obj.ComplexData
+                if channel > chans/2
+                    error('System has only %d DDS channel(s)', chans);
+                end
+            else
+                if channel > chans
+                    error('System has only %d DDS channel(s)', chans);
+                end                
+            end
+
+
+
+            % All channels have 2 DDS tone generators which are controlled
+            % by the second row of all the DDS* properties
+
+            % Reset everything to zero
+            obj.DDSScales = zeros(2,chans);
+            obj.DDSPhases = zeros(2,chans);
+            obj.DDSFrequencies = zeros(2,chans);
+
+            if obj.ComplexData
+                % For complex channels DDS channels go I1,Q1,I2,Q2,...
+                iChanIndx = (channel-1)*2+1;
+                qChanIndx = iChanIndx + 1;
+            else
+                % For real only systems channels go C1,C2,C3,...
+                iChanIndx = channel;
+                qChanIndx = channel;
+            end
+
+            freqs = zeros(2,chans);
+            freqs(1,iChanIndx) = abs(frequency);
+            freqs(1,qChanIndx) = abs(frequency);
+            obj.DDSFrequencies = freqs;
+
+            if obj.ComplexData
+                phases = zeros(2,chans);
+                if frequency >=0
+                    phases(1,iChanIndx) = 90000;
+                    phases(1,qChanIndx) = 0;
+                else
+                    phases(1,iChanIndx) = 0;
+                    phases(1,qChanIndx) = 90000;
+                end
+                obj.DDSPhases = phases;
+            end
+
+            scales = zeros(2,chans);
+            scales(1,iChanIndx) = scale;
+            scales(1,qChanIndx) = scale;
+            obj.DDSScales = scales;
+
+        end
         
     end
     


### PR DESCRIPTION
This PR adds a helper function to the DDS control to set tones more easily. Until now you have to manually set all the DDS properties to generate simple tones.